### PR TITLE
Added UNIQUE support

### DIFF
--- a/lib/sqlite3.js
+++ b/lib/sqlite3.js
@@ -524,8 +524,12 @@ SQLite3.prototype.propertiesSQL = function (model) {
 
 SQLite3.prototype.propertySettingsSQL = function (model, prop) {
     var p = this._models[model].properties[prop];
-    return datatype(p) + ' ' +
-    (p.allowNull === false || p['null'] === false ? 'NOT NULL' : 'NULL') +
+    return datatype(p) + 
+    //// In case in the future support user defined PK, un-comment the following:
+    // (p.primaryKey === true ? ' PRIMARY KEY' : '') +
+    // (p.primaryKey === true && p.autoIncrement === true ? ' AUTOINCREMENT' : '') +
+    (p.allowNull === false || p['null'] === false ? ' NOT NULL' : ' NULL') +
+    (p.unique === true ? ' UNIQUE' : '') +
     (typeof p.default === "number" ? ' DEFAULT ' + p.default :'') +
     (typeof p.default === "string" ? ' DEFAULT \'' + p.default + '\'' :'');
 };


### PR DESCRIPTION
Added UNIQUE support, SQLite will automatically create the INDEX.

Example usage:

``` javascript
var Data = schema.define('Data', {
        // num: { type: Number, primaryKey: true, autoIncrement: true},
    key: { type: String, index: true, unique: true, null: false },
    value: String
});
```

This will generate:

``` SQL
CREATE TABLE `Data` (
  `id` INTEGER PRIMARY KEY,
  `key` VARCHAR(255) NOT NULL UNIQUE,
  `value` VARCHAR(255) NULL
);
```
