### PR TITLE
Fixed handling of ```>=``` and ```<=``` for dates

### DIFF
--- a/lib/sqlite3.js
+++ b/lib/sqlite3.js
@@ -342,12 +342,11 @@ function buildWhere(conds) {
                 	sqlCond += '(' + val + ')';
                 } else if (condType == 'like') {
                 	sqlCond += "'" + val + "'";
-                } else {
-                	sqlCond += val;
                 }
+
                 if (condType !== 'between' && condType !== 'inq' && condType !== 'nin' && condType !== 'like') {
                     sqlCond += '?';
-                    queryParams.push(conds[key][condType]);
+                    queryParams.push(self.toDatabase(props[key],conds[key][condType]));
                 }
                 cs.push(sqlCond);
             } else {


### PR DESCRIPTION
I am not sure that this works for all cases. But it fixes the issue I reported (#18) for the `gte` and ``lte` for dates.

Note: in particular I am worried about what would happen for a `between` call. Also do we need to add some unti testing for this type of call?
