### PR TITLE
Fix SQLITE_ERROR when where:{} is used

### DIFF
--- a/lib/sqlite3.js
+++ b/lib/sqlite3.js
@@ -354,7 +354,11 @@ function buildWhere(conds) {
                 queryParams.push(self.toDatabase(props[key], conds[key]));
             }
         });
-        return 'WHERE ' + cs.join(' AND ');
+        if (cs.length > 0){
+            return 'WHERE ' + cs.join(' AND ');
+        } else {
+            return ''
+        }
     }
 
     function buildOrderBy(order) {


### PR DESCRIPTION
Without this guard block, at times invalid SQL is generated by the module. Specifically if where:{} is specified in the query. I believe it is a fairly common use case to initialize a filter_condition with an empty object and then add conditions to it and pass it as where argument. Having no conditions is a special case, and when it can be dealt with at the module level trivially easily, it is best to do so.
