### PR TITLE
[schema] add schema to sqlite adapter

### DIFF
--- a/lib/sqlite3.js
+++ b/lib/sqlite3.js
@@ -13,11 +13,14 @@ exports.initialize = function initializeSchema(schema, callback) {
     schema.client = db;
 
     schema.adapter = new SQLite3(schema.client);
+    schema.adapter.schema = schema;
+    
     if (s.database === ':memory:') {
         schema.adapter.automigrate(callback);
     } else {
         process.nextTick(callback);
     }
+
 };
 
 function SQLite3(client) {


### PR DESCRIPTION
According to commit https://github.com/1602/jugglingdb/commit/cc5b0e9145de7ba73a1318f23dfbbf67dfb0605e, schema is required in adapter.
