### PR TITLE
Debug mode

### DIFF
--- a/lib/sqlite3.js
+++ b/lib/sqlite3.js
@@ -9,12 +9,13 @@ exports.initialize = function initializeSchema(schema, callback) {
     var s = schema.settings;
 
     var Database = null;
-    switch (s.mode) {
+    switch (s.type) {
         case 'cached':
             Database = sqlite3.cached.Database;
             break;
         case 'normal':
             Database = sqlite3.Database;
+            break;
         case 'verbose':
         default: 
             Database = sqlite3.verbose().Database;

--- a/lib/sqlite3.js
+++ b/lib/sqlite3.js
@@ -14,10 +14,10 @@ exports.initialize = function initializeSchema(schema, callback) {
             Database = sqlite3.cached.Database;
             break;
         case 'normal':
+        default:
             Database = sqlite3.Database;
             break;
         case 'verbose':
-        default: 
             Database = sqlite3.verbose().Database;
     }
 

--- a/lib/sqlite3.js
+++ b/lib/sqlite3.js
@@ -7,7 +7,19 @@ var jdb = require('jugglingdb');
 exports.initialize = function initializeSchema(schema, callback) {
     if (!sqlite3) return;
     var s = schema.settings;
-    var Database = sqlite3.verbose().Database;
+
+    var Database = null;
+    switch (s.mode) {
+        case 'cached':
+            Database = sqlite3.cached.Database;
+            break;
+        case 'normal':
+            Database = sqlite3.Database;
+        case 'verbose':
+        default: 
+            Database = sqlite3.verbose().Database;
+    }
+
     var db = new Database(s.database);
 
     schema.client = db;


### PR DESCRIPTION
As explained in the node sqlite3 module, verbose should not be used as production. So, I've added a parameter "type" (not sure if it's very relevant...?). 

I'm not sure if it usefull to be verbose by default in other parts of jugglingdb so I let it by default. Maybe it should be better to be cached or normal by default. Why do you think about that ?