### PR TITLE
Added callback parameter to disconnect()

### DIFF
--- a/lib/sqlite3.js
+++ b/lib/sqlite3.js
@@ -422,8 +422,8 @@ SQLite3.prototype.count = function count(model, callback, where) {
     }
 };
 
-SQLite3.prototype.disconnect = function disconnect() {
-    this.client.close();
+SQLite3.prototype.disconnect = function disconnect(cb) {
+    this.client.close(cb);
 };
 
 SQLite3.prototype.isActual = function (cb) {


### PR DESCRIPTION
The disconnect() function was missing a callback parameter, which its callee is providing and 'this.client.close' is expecting.
Related to https://github.com/1602/jugglingdb/pull/440