### PR TITLE
fix missing toDatabase conversion in save()

### DIFF
--- a/lib/sqlite3.js
+++ b/lib/sqlite3.js
@@ -63,11 +63,12 @@ SQLite3.prototype.query = function (method, args) {
 
 SQLite3.prototype.save = function (model, data, callback) {
     var queryParams = [];
+    var props = this._models[model].properties;
     var sql = 'UPDATE ' + this.tableEscaped(model) + ' SET ' +
-    Object.keys(data).map(function (key) {
-        queryParams.push(data[key]);
+        Object.keys(data).map(function (key) {
+        queryParams.push(this.toDatabase(props[key], data[key]));
         return '`' + key + '` = ?';
-    }).join(', ') + ' WHERE id = ' + data.id;
+    }.bind(this)).join(', ') + ' WHERE id = ' + data.id;
 
     this.command(sql, queryParams, function (err) {
         callback(err);


### PR DESCRIPTION
An attribute of model type Schema.JSON is nullified when updated. E.g. the following code gives:
TypeError: Cannot read property 'dummy' of null

    var Schema = require('jugglingdb').Schema;
    var schema = new Schema('sqlite3', {database: ":memory:"});
    var Data = schema.define('Data', {
        val:          Schema.JSON
    });
    schema.autoupdate(function() {
        var data = new Data({dummy: true});
        data.save(function(err, newData) {
            data.updateAttributes({val: {dummy: false}}, function(err, datas) {
                Data.all(function(err, datas) {
                    console.log(datas[0].val.dummy);
                });
            });
        });
    });