### PR TITLE
fix node v8.x and above compatability

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "debug": "^2.2.0",
     "jugglingdb": "=2.0.0-rc8",
-    "sqlite3": "=3.1.8"
+    "sqlite3": "^3.1.8"
   },
   "devDependencies": {
     "eslint": "^3.1.0",


### PR DESCRIPTION
Fixes https://github.com/jugglingdb/sqlite3-adapter/issues/42

Atlassian's [Confluence Plugin tutorial](https://developer.atlassian.com/cloud/confluence/getting-started/) has a [PoC](https://bitbucket.org/atlassian/confluence-helloworld-addon) that relies on jugglingdb-sqlite3, which is how I tripped over this.

/cc @1602 @haas85 