### PR TITLE
Upgrade sqlite3 from 3 to 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "debug": "^2.2.0",
     "jugglingdb": "=2.0.0-rc8",
-    "sqlite3": "^3.1.8"
+    "sqlite3": "^4.0.2"
   },
   "devDependencies": {
     "eslint": "^3.1.0",


### PR DESCRIPTION
- Fix failed building sqlite3. 
  - See also: https://github.com/mapbox/node-sqlite3/issues/997